### PR TITLE
Changed anon-note length from 3200 to 2000

### DIFF
--- a/commands/anon-note.js
+++ b/commands/anon-note.js
@@ -14,7 +14,7 @@ module.exports = {
 				.setLabel('Note')
 				.setPlaceholder('What\'s on your mind?')
 				.setStyle(TextInputStyle.Paragraph)
-				.setMaxLength(3200)
+				.setMaxLength(2000)
 				.setRequired(true);
 			noteRow.addComponents(noteBox);
 			const modal = new ModalBuilder()


### PR DESCRIPTION
Discord's API doesn't make the character limits clear. Perhaps in a future version we'll have better validation.